### PR TITLE
Revert "Bump tar from 6.2.0 to 6.2.1"

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -379,7 +379,7 @@ packages:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.5.4
-      tar: 6.2.1
+      tar: 6.2.0
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -578,7 +578,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@rollup/plugin-alias@5.1.0(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-alias@5.1.0(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-lpA3RZ9PdIG7qqhEfv79tBffNaoDuukFDrmhLqg9ifv99u/ehn+lOg30x2zmhf8AQqQUZaMk/B9fZraQ6/acDQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -587,11 +587,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
       slash: 4.0.0
     dev: false
 
-  /@rollup/plugin-commonjs@25.0.7(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-commonjs@25.0.7(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-nEvcR+LRjEjsaSsc4x3XZfCCvZIaSMenZu/OiwOKGN2UhQpAYI7ru7czFvyWbErlpoGjnSX3D5Ch5FcMA3kRWQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -600,16 +600,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
       commondir: 1.0.1
       estree-walker: 2.0.2
       glob: 8.1.0
       is-reference: 1.2.1
       magic-string: 0.30.5
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
     dev: false
 
-  /@rollup/plugin-inject@5.0.5(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-inject@5.0.5(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -618,13 +618,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
       estree-walker: 2.0.2
       magic-string: 0.30.5
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
     dev: false
 
-  /@rollup/plugin-json@6.1.0(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-json@6.1.0(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -633,11 +633,11 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
-      rollup: /@rollup/wasm-node@4.14.1
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
+      rollup: /@rollup/wasm-node@4.12.0
     dev: false
 
-  /@rollup/plugin-node-resolve@15.2.3(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-node-resolve@15.2.3(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-j/lym8nf5E21LwBT4Df1VD6hRO2L2iwUeUmP7litikRsVp1H6NWx20NEp0Y7su+7XGc476GnXXc4kFeZNGmaSQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -646,16 +646,16 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-builtin-module: 3.2.1
       is-module: 1.0.0
       resolve: 1.22.4
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
     dev: false
 
-  /@rollup/plugin-replace@5.0.5(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-replace@5.0.5(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -664,12 +664,12 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
       magic-string: 0.30.5
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
     dev: false
 
-  /@rollup/plugin-terser@0.4.4(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-terser@0.4.4(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -678,13 +678,13 @@ packages:
       rollup:
         optional: true
     dependencies:
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
       serialize-javascript: 6.0.1
       smob: 1.4.0
       terser: 5.19.4
     dev: false
 
-  /@rollup/plugin-wasm@6.2.2(@rollup/wasm-node@4.14.1):
+  /@rollup/plugin-wasm@6.2.2(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-gpC4R1G9Ni92ZIRTexqbhX7U+9estZrbhP+9SRb0DW9xpB9g7j34r+J2hqrcW/lRI7dJaU84MxZM0Rt82tqYPQ==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -693,8 +693,8 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
-      rollup: /@rollup/wasm-node@4.14.1
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
+      rollup: /@rollup/wasm-node@4.12.0
     dev: false
 
   /@rollup/pluginutils@4.2.1:
@@ -705,7 +705,7 @@ packages:
       picomatch: 2.3.1
     dev: false
 
-  /@rollup/pluginutils@5.1.0(@rollup/wasm-node@4.14.1):
+  /@rollup/pluginutils@5.1.0(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
@@ -717,11 +717,11 @@ packages:
       '@types/estree': 1.0.1
       estree-walker: 2.0.2
       picomatch: 2.3.1
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
     dev: false
 
-  /@rollup/wasm-node@4.14.1:
-    resolution: {integrity: sha512-w5GZ2p1F7tOop6WJxa5x0Ot1s6eVPKOlEo5hmWT3KGxv0naGqiGJa/fz7S/it06nzgS3fmkDbtDfpAYwqOMKRQ==}
+  /@rollup/wasm-node@4.12.0:
+    resolution: {integrity: sha512-sqy3+YvV/uWX6bPZOR5PlEdH6xyMPXoelllRQ/uZ13tzy9f4pXZTbajnoWN8IHHXwTNKPiLzsePLiDEVmkxMNw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
@@ -2162,7 +2162,7 @@ packages:
       nypm: 0.3.4
       ohash: 1.1.3
       pathe: 1.1.1
-      tar: 6.2.1
+      tar: 6.2.0
     dev: false
 
   /glob-parent@5.1.2:
@@ -2884,15 +2884,15 @@ packages:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.3.0
       '@netlify/functions': 2.4.1
-      '@rollup/plugin-alias': 5.1.0(@rollup/wasm-node@4.14.1)
-      '@rollup/plugin-commonjs': 25.0.7(@rollup/wasm-node@4.14.1)
-      '@rollup/plugin-inject': 5.0.5(@rollup/wasm-node@4.14.1)
-      '@rollup/plugin-json': 6.1.0(@rollup/wasm-node@4.14.1)
-      '@rollup/plugin-node-resolve': 15.2.3(@rollup/wasm-node@4.14.1)
-      '@rollup/plugin-replace': 5.0.5(@rollup/wasm-node@4.14.1)
-      '@rollup/plugin-terser': 0.4.4(@rollup/wasm-node@4.14.1)
-      '@rollup/plugin-wasm': 6.2.2(@rollup/wasm-node@4.14.1)
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
+      '@rollup/plugin-alias': 5.1.0(@rollup/wasm-node@4.12.0)
+      '@rollup/plugin-commonjs': 25.0.7(@rollup/wasm-node@4.12.0)
+      '@rollup/plugin-inject': 5.0.5(@rollup/wasm-node@4.12.0)
+      '@rollup/plugin-json': 6.1.0(@rollup/wasm-node@4.12.0)
+      '@rollup/plugin-node-resolve': 15.2.3(@rollup/wasm-node@4.12.0)
+      '@rollup/plugin-replace': 5.0.5(@rollup/wasm-node@4.12.0)
+      '@rollup/plugin-terser': 0.4.4(@rollup/wasm-node@4.12.0)
+      '@rollup/plugin-wasm': 6.2.2(@rollup/wasm-node@4.12.0)
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
       '@types/http-proxy': 1.17.14
       '@vercel/nft': 0.24.4
       archiver: 6.0.1
@@ -2933,8 +2933,8 @@ packages:
       pkg-types: 1.0.3
       pretty-bytes: 6.1.1
       radix3: 1.1.0
-      rollup: /@rollup/wasm-node@4.14.1
-      rollup-plugin-visualizer: 5.12.0(@rollup/wasm-node@4.14.1)
+      rollup: /@rollup/wasm-node@4.12.0
+      rollup-plugin-visualizer: 5.12.0(@rollup/wasm-node@4.12.0)
       scule: 1.1.1
       semver: 7.5.4
       serve-placeholder: 2.0.1
@@ -2944,7 +2944,7 @@ packages:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.9.0
-      unimport: 3.7.1(@rollup/wasm-node@4.14.1)
+      unimport: 3.7.1(@rollup/wasm-node@4.12.0)
       unstorage: 1.10.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -3411,7 +3411,7 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-visualizer@5.12.0(@rollup/wasm-node@4.14.1):
+  /rollup-plugin-visualizer@5.12.0(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-8/NU9jXcHRs7Nnj07PF2o4gjxmm9lXIrZ8r175bT9dK8qoLlvKTwRMArRCMgpMGlq8CTLugRvEmyMeMXIU2pNQ==}
     engines: {node: '>=14'}
     hasBin: true
@@ -3423,7 +3423,7 @@ packages:
     dependencies:
       open: 8.4.2
       picomatch: 2.3.1
-      rollup: /@rollup/wasm-node@4.14.1
+      rollup: /@rollup/wasm-node@4.12.0
       source-map: 0.7.4
       yargs: 17.7.2
     dev: false
@@ -3738,8 +3738,8 @@ packages:
       streamx: 2.15.1
     dev: false
 
-  /tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+  /tar@6.2.0:
+    resolution: {integrity: sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==}
     engines: {node: '>=10'}
     dependencies:
       chownr: 2.0.0
@@ -3916,10 +3916,10 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /unimport@3.7.1(@rollup/wasm-node@4.14.1):
+  /unimport@3.7.1(@rollup/wasm-node@4.12.0):
     resolution: {integrity: sha512-V9HpXYfsZye5bPPYUgs0Otn3ODS1mDUciaBlXljI4C2fTwfFpvFZRywmlOu943puN9sncxROMZhsZCjNXEpzEQ==}
     dependencies:
-      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.14.1)
+      '@rollup/pluginutils': 5.1.0(@rollup/wasm-node@4.12.0)
       acorn: 8.11.3
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3


### PR DESCRIPTION
Reverts niteshraj2310/simple-proxy#2

## Summary by Sourcery

Chores:
- Downgrade `@rollup/wasm-node` from 4.14.1 to 4.12.0.